### PR TITLE
feat: bracketSameLine option

### DIFF
--- a/__tests__/fixtures/formattedWithOption/bracket_same_line.blade.php
+++ b/__tests__/fixtures/formattedWithOption/bracket_same_line.blade.php
@@ -1,0 +1,4 @@
+<div id="foo-bar-baz" class="bar-foo-baz" title="a sample title" data-foo="bar" data-bar="baz">
+  lorem ipsum dolor sit amet
+</div>
+

--- a/__tests__/fixtures/formattedWithOption/formatted.bracket_same_line.blade.php
+++ b/__tests__/fixtures/formattedWithOption/formatted.bracket_same_line.blade.php
@@ -1,0 +1,7 @@
+<div id="foo-bar-baz"
+     class="bar-foo-baz"
+     title="a sample title"
+     data-foo="bar"
+     data-bar="baz">
+    lorem ipsum dolor sit amet
+</div>

--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -115,4 +115,32 @@ describe("option test", () => {
       .toString("utf-8");
     expect(result).toEqual(expected);
   });
+  test.concurrent(
+    `can format fixture with bracketSameLine option`,
+    function () {
+      const content = fs
+        .readFileSync(path.resolve(fixturesDir, "bracket_same_line.blade.php"))
+        .toString("utf-8");
+
+      const plugin = require(path.resolve(__dirname, "../"));
+
+      const result = prettier.format(content, {
+        plugins: [{ ...plugin }],
+        parser: "blade",
+        pluginSearchDirs: [path.resolve(__dirname, "../")],
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        bracketSameLine: true,
+      });
+      const expected = fs
+        .readFileSync(
+          path.resolve(
+            formattedFixturesDir,
+            `formatted.bracket_same_line.blade.php`
+          )
+        )
+        .toString("utf-8");
+      expect(result).toEqual(expected);
+    }
+  );
 });

--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -51,7 +51,11 @@ describe("broken text test", () => {
 });
 
 describe("option test", () => {
-  const fixturesDir = path.resolve(__dirname, "fixtures", "formattedWithOption");
+  const fixturesDir = path.resolve(
+    __dirname,
+    "fixtures",
+    "formattedWithOption"
+  );
   const formattedFixturesDir = path.resolve(
     __dirname,
     "fixtures",
@@ -90,31 +94,44 @@ describe("option test", () => {
       sortTailwindcssClasses: true,
     });
     const expected = fs
-      .readFileSync(path.resolve(formattedFixturesDir, `formatted.tailwindcss.blade.php`))
+      .readFileSync(
+        path.resolve(formattedFixturesDir, `formatted.tailwindcss.blade.php`)
+      )
       .toString("utf-8");
     expect(result).toEqual(expected);
   });
 
-  test.concurrent(`can format fixture with singleAttributePerLine options`, function () {
-    const content = fs
-      .readFileSync(path.resolve(fixturesDir, "single_attribute_per_line.blade.php"))
-      .toString("utf-8");
+  test.concurrent(
+    `can format fixture with singleAttributePerLine options`,
+    function () {
+      const content = fs
+        .readFileSync(
+          path.resolve(fixturesDir, "single_attribute_per_line.blade.php")
+        )
+        .toString("utf-8");
 
-    const plugin = require(path.resolve(__dirname, "../"));
+      const plugin = require(path.resolve(__dirname, "../"));
 
-    const result = prettier.format(content, {
-      plugins: [{ ...plugin }],
-      parser: "blade",
-      pluginSearchDirs: [path.resolve(__dirname, "../")],
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      singleAttributePerLine: true,
-    });
-    const expected = fs
-      .readFileSync(path.resolve(formattedFixturesDir, `formatted.single_attribute_per_line.blade.php`))
-      .toString("utf-8");
-    expect(result).toEqual(expected);
-  });
+      const result = prettier.format(content, {
+        plugins: [{ ...plugin }],
+        parser: "blade",
+        pluginSearchDirs: [path.resolve(__dirname, "../")],
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        singleAttributePerLine: true,
+      });
+      const expected = fs
+        .readFileSync(
+          path.resolve(
+            formattedFixturesDir,
+            `formatted.single_attribute_per_line.blade.php`
+          )
+        )
+        .toString("utf-8");
+      expect(result).toEqual(expected);
+    }
+  );
+
   test.concurrent(
     `can format fixture with bracketSameLine option`,
     function () {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -10,7 +10,7 @@ export const parse = (
   const formatterOptions: FormatterOption = {
     indentSize: opts.tabWidth,
     wrapLineLength: opts.printWidth,
-    wrapAttributes: opts.singleAttributePerLine ? 'force-expand-multiline' : opts.wrapAttributes,
+    wrapAttributes: opts.singleAttributePerLine ? 'force-expand-multiline' : opts.bracketSameLine ? 'force-aligned' : opts.wrapAttributes,
     endWithNewline: opts.endWithNewline,
     useTabs: opts.useTabs,
     sortTailwindcssClasses: opts.sortTailwindcssClasses,


### PR DESCRIPTION
- feat: 🎸 bracketSameLine option
- test: 💍 add test for bracketSameLine option
- style: 💄 apply format

## Context
- close: https://github.com/shufo/prettier-plugin-blade/issues/59

## Motivation
`bracketSameLine` option supported in Prettier is currently not supported in this plugin.

## Solution
If the `bracketSameLine` is specified by config, interpret the `wrapAttributes` as being specified as `force-aligned`.