### PR TITLE
fix: bump blade-formatter to 1.27.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,22 +135,24 @@ https://user-images.githubusercontent.com/1641039/151354641-6305805e-8e0c-4226-8
 
 You can use these options for prettier blade plugin in prettier CLI.
 
-|                          key |                                                                                                                                                   description |
-| ---------------------------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------: |
-|                `--tab-width` |                                                                                                          Number of spaces per indentation level. default: `4` |
-|              `--print-width` |                                                                                                  The line length where Prettier will try wrap. default: `120` |
-|          `--wrap-attributes` | The way to wrap attributes. [`auto`\|`force`\|`force-aligned`\|`force-expand-multiline`\|`aligned-multiple`\|`preserve`\|`preserve-aligned`]. default: `auto` |
-|        `--end-with-new-line` |                                                                                                                      End output with newline. default: `true` |
-| `--sort-tailwindcss-classes` |                                                       Sort Tailwind CSS classes. It will lookup and respects `tailwind.config.js` if exists. default: `false` |
+|                          key |                                                                                                                                                                                                                                               description |
+| ---------------------------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
+|                `--tab-width` |                                                                                                                                                                                                      Number of spaces per indentation level. default: `4` |
+|              `--print-width` |                                                                                                                                                                                              The line length where Prettier will try wrap. default: `120` |
+|          `--wrap-attributes` |                                                                                             The way to wrap attributes. [`auto`\|`force`\|`force-aligned`\|`force-expand-multiline`\|`aligned-multiple`\|`preserve`\|`preserve-aligned`]. default: `auto` |
+|        `--end-with-new-line` |                                                                                                                                                                                                                  End output with newline. default: `true` |
+| `--sort-tailwindcss-classes` |                                                                                                                                                   Sort Tailwind CSS classes. It will lookup and respects `tailwind.config.js` if exists. default: `false` |
+|     `--sort-html-attributes` | Sort HTML attributes. [`none` \| `alphabetical` \| [`code-guide`](https://codeguide.co/) \| [`idiomatic`](https://github.com/necolas/idiomatic-html#attribute-order) \| [`vuejs`](https://eslint.vuejs.org/rules/attributes-order.html)] default: `false` |
 
 ### `.prettierrc` example
 
 ```json
 {
-  "printWidth": 120,
-  "tabWidth": 4,
-  "wrapAttributes": "auto",
-  "sortTailwindcssClasses": true
+    "printWidth": 120,
+    "tabWidth": 4,
+    "wrapAttributes": "auto",
+    "sortTailwindcssClasses": true,
+    "sortHtmlAttributes": "none"
 }
 ```
 

--- a/__tests__/fixtures/formatted/formatted.append_tag.blade.php
+++ b/__tests__/fixtures/formatted/formatted.append_tag.blade.php
@@ -2,7 +2,6 @@
     @section('css')
         <style>
             td a {
-
                 text-decoration: underline !important;
             }
         </style>

--- a/__tests__/fixtures/formatted/formatted.overwrite_tag.blade.php
+++ b/__tests__/fixtures/formatted/formatted.overwrite_tag.blade.php
@@ -2,7 +2,6 @@
     @section('css')
         <style>
             td a {
-
                 text-decoration: underline !important;
             }
         </style>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "version": "1.4.22",
   "dependencies": {
-    "blade-formatter": "^1.26.17",
+    "blade-formatter": "^1.27.0",
     "prettier": "^2.6.2",
     "synckit": "^0.8.1"
   },

--- a/src/options.ts
+++ b/src/options.ts
@@ -26,5 +26,12 @@ export const options = {
     description: "Sort Tailwindcss classes automatically. This option respects `tailwind.config.js`.",
     since: "1.0.0",
   },
+  sortHtmlAttributes: {
+    type: "string",
+    category: "Blade",
+    default: "none",
+    description: "Sort HTML Attributes. [none|alphabetical|code-guide|idiomatic|vuejs]",
+    since: "1.5.0",
+  },
 };
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -15,6 +15,7 @@ export const parse = (
     useTabs: opts.useTabs,
     sortTailwindcssClasses: opts.sortTailwindcssClasses,
     sortHtmlAttributes: opts.sortHtmlAttributes,
+    noMultipleEmptyLines: true,
   };
 
   const syncFn = createSyncFn(require.resolve("./worker"));

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -14,6 +14,7 @@ export const parse = (
     endWithNewline: opts.endWithNewline,
     useTabs: opts.useTabs,
     sortTailwindcssClasses: opts.sortTailwindcssClasses,
+    sortHtmlAttributes: opts.sortHtmlAttributes,
   };
 
   const syncFn = createSyncFn(require.resolve("./worker"));

--- a/yarn.lock
+++ b/yarn.lock
@@ -1251,10 +1251,10 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
-blade-formatter@^1.26.17:
-  version "1.26.17"
-  resolved "https://registry.yarnpkg.com/blade-formatter/-/blade-formatter-1.26.17.tgz#14d2fcca7052a5ab7e0ad3603562b62575e40cfc"
-  integrity sha512-sEP8JjDvlfg6QdLrWQ19RfpUf869xg8PgBGSV8r1FRuYTf93iWHKTqFqw8REdDAq6GdC3QKE6jURB5/3vZQVmQ==
+blade-formatter@^1.27.0:
+  version "1.27.0"
+  resolved "https://registry.yarnpkg.com/blade-formatter/-/blade-formatter-1.27.0.tgz#3c052aa83af5208e272477c1442107d5b102e178"
+  integrity sha512-JyaUS10fAKVcpBnk6kC2/SyNx1iIWIpoPVcOIIvYYwVNAqyRMpf75Tc0X1+VJ3r7Ck0S9IG305hiPlj2FeNUzQ==
   dependencies:
     "@prettier/plugin-php" "^0.18.0"
     "@shufo/tailwindcss-class-sorter" "^1.0.3"
@@ -1265,6 +1265,7 @@ blade-formatter@^1.26.17:
     detect-indent "^6.0.0"
     find-config "^1.0.0"
     glob "^8.0.1"
+    html-attribute-sorter "^0.4.0"
     ignore "^5.1.8"
     js-beautify "^1.14.0"
     lodash "^4.17.19"
@@ -2194,6 +2195,11 @@ has@^1.0.3:
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
   dependencies:
     function-bind "^1.1.1"
+
+html-attribute-sorter@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/html-attribute-sorter/-/html-attribute-sorter-0.4.0.tgz#c9021e51f8170fd971296497884fc32d3fe18db8"
+  integrity sha512-GxGTu1FtmABg/5AUovWnIxmOEJMvZOMqBnmRuut2bLfxy/Tn+pI93l0devqaB9UkG8UoviTLJtOqz1+DBHqtbA==
 
 html-escaper@^2.0.0:
   version "2.0.2"


### PR DESCRIPTION
- chore: 🤖 bump blade-formatter to 1.27.0
- feat: 🎸 sort html attributes option
- fix: 🐛 support prettier's no multiple empty lines behaviour
