### PR TITLE
Fix endOfLine not passed to blade-formatter

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -20,6 +20,7 @@ export const parse = (
     noMultipleEmptyLines: true,
     noPhpSyntaxCheck: opts.noPhpSyntaxCheck,
     customHtmlAttributesOrder: opts.customHtmlAttributesOrder,
+    endOfLine: opts.endOfLine === 'crlf' ? 'CRLF' : 'LF',
   };
 
   const syncFn = createSyncFn(require.resolve("./worker"));


### PR DESCRIPTION
Currently the plugin doesn't respect prettier's `endOfLine` setting, and leaves it up to blade-formatter to choose between LF and CRLF. This becomes an issue on Windows, when the project files use LF rather than CRLF.

This small change will force blade-formatter to use LF line endings unless prettier's option is set to `crlf`. I don't know if there are any potential issues with this approach, but it works as intended as far as I can tell.