### PR TITLE
feat: add option `--component-prefix`

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,8 @@ You can use these options for prettier blade plugin in prettier CLI.
   "noPhpSyntaxCheck": false,
   "indentInnerHtml": true,
   "extraLiners": "",
-  "trailingCommaPHP": true
+  "trailingCommaPHP": true,
+  "componentPrefix": "x-,livewire"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ You can use these options for prettier blade plugin in prettier CLI.
 |       `--no-php-syntax-check` | Disable PHP syntax checking. default: `false`                                                                                                                                                                                                                                   |
 |              `--extra-liners` | Comma separated list of tags that should have an extra newline before them. default: `head,body,/html`                                                                                                                                                                          |
 |        `--trailing-comma-php` | If set to false, no trailing commas are printed for php expression. default: `true`                                                                                                                                                                                             |
+|          `--component-prefix` | Comma separated list of component prefix use to preserve style in html attributes. default: `x-,livewire`                                                                                                                                                                       |
 
 ### `.prettierrc` example
 

--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -161,6 +161,23 @@ describe("CLI test", () => {
 			to: "formatted.index.blade.php",
 		},
 		{
+			name: ".prettierrc.json with component prefix option",
+			fromDir: path.resolve(
+				"__tests__",
+				"fixtures",
+				"runtimeConfig",
+				"componentPrefix",
+			),
+			from: "index.blade.php",
+			toDir: path.resolve(
+				"__tests__",
+				"fixtures",
+				"runtimeConfig",
+				"componentPrefix",
+			),
+			to: "formatted.index.blade.php",
+		},
+		{
 			name: ".prettierrc.json with trailing comma php option",
 			fromDir: path.resolve(
 				"__tests__",

--- a/__tests__/fixtures/runtimeConfig/componentPrefix/.prettierrc.json
+++ b/__tests__/fixtures/runtimeConfig/componentPrefix/.prettierrc.json
@@ -1,0 +1,14 @@
+{
+	"overrides": [
+		{
+			"files": ["*.blade.php"],
+			"options": {
+				"tabWidth": 4,
+				"parser": "blade"
+			}
+		}
+	],
+	"printWidth": 120,
+	"tabWidth": 4,
+	"componentPrefix": "foo"
+}

--- a/__tests__/fixtures/runtimeConfig/componentPrefix/formatted.index.blade.php
+++ b/__tests__/fixtures/runtimeConfig/componentPrefix/formatted.index.blade.php
@@ -1,0 +1,2 @@
+<foo:button :key="$foo->bar">
+</foo:button>

--- a/__tests__/fixtures/runtimeConfig/componentPrefix/index.blade.php
+++ b/__tests__/fixtures/runtimeConfig/componentPrefix/index.blade.php
@@ -1,0 +1,2 @@
+<foo:button :key="$foo->bar">
+</foo:button>

--- a/__tests__/formatter.test.ts
+++ b/__tests__/formatter.test.ts
@@ -358,4 +358,43 @@ describe("option test", () => {
 			expect(result).toEqual(expected);
 		},
 	);
+
+	test.concurrent(
+		"can format fixture with component prefix option",
+		async () => {
+			const content = fs
+				.readFileSync(
+					path.resolve(
+						__dirname,
+						"fixtures",
+						"runtimeConfig",
+						"componentPrefix",
+						"index.blade.php",
+					),
+				)
+				.toString("utf-8");
+
+			const result = await prettier.format(content, {
+				plugins: [plugin],
+				parser: "blade",
+				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+				// @ts-ignore
+				componentPrefix: "foo",
+			});
+
+			const expected = fs
+				.readFileSync(
+					path.resolve(
+						__dirname,
+						"fixtures",
+						"runtimeConfig",
+						"componentPrefix",
+						"formatted.index.blade.php",
+					),
+				)
+				.toString("utf-8");
+
+			expect(result).toEqual(expected);
+		},
+	);
 });

--- a/__tests__/parser.test.ts
+++ b/__tests__/parser.test.ts
@@ -28,6 +28,7 @@ describe("parse", () => {
 			customHtmlAttributesOrder: [],
 			indentInnerHtml: false,
 			extraLiners: "",
+			componentPrefix: "",
 			filepath: undefined,
 		};
 

--- a/biome.json
+++ b/biome.json
@@ -9,5 +9,9 @@
 			"recommended": true
 		},
 		"ignore": ["coverage/**", ".yalc/**", "dist/**"]
+	},
+	"formatter": {
+		"enabled": true,
+		"ignore": ["package.json", "README.md"]
 	}
 }

--- a/src/options.ts
+++ b/src/options.ts
@@ -34,6 +34,7 @@ export const defaultOptions = {
  * @property {Object} noPhpSyntaxCheck - Whether to disable PHP syntax checking.
  * @property {Object} indentInnerHtml - Whether to indent <head> and <body> sections in html.
  * @property {Object} extraLiners - Comma separated list of tags that should have an extra newline before them.
+ * @property {Object} componentPrefix - Comma separated list of component prefixes use to preserve style in html attributes.
  * @property {Object} trailingCommaPHP - Whether to print trailing commas for php expression.
  * @property {Object} phpVersion - The version of PHP to use for formatting.
  * @since 1.0.0
@@ -130,6 +131,13 @@ export const options = {
 		default: "8.1",
 		description: "The version of PHP to use for formatting.",
 		since: "1.13.0",
+	},
+	componentPrefix: {
+		type: "string",
+		category: "Blade",
+		default: "x-,livewire",
+		description: "Comma separated list of component prefix use to preserve style in html attributes.",
+		since: "1.15.0",
 	},
 };
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -136,7 +136,8 @@ export const options = {
 		type: "string",
 		category: "Blade",
 		default: "x-,livewire",
-		description: "Comma separated list of component prefix use to preserve style in html attributes.",
+		description:
+			"Comma separated list of component prefix use to preserve style in html attributes.",
 		since: "1.15.0",
 	},
 };

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -41,6 +41,7 @@ export const parse = async (
 		noTrailingCommaPhp: phpVersion < 7.2 || !opts.trailingCommaPHP,
 		customHtmlAttributesOrder: opts.customHtmlAttributesOrder,
 		indentInnerHtml: opts.indentInnerHtml,
+		componentPrefix: opts.componentPrefix?.split(","),
 		// @ts-ignore
 		extraLiners: opts.extraLiners.split(","),
 	};


### PR DESCRIPTION
## Context

- <https://github.com/shufo/blade-formatter/pull/943>

This PR adds option `--component-prefix` introduced in blade-formatter 1.42.0
