### PR TITLE
✏️ move prettier to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,10 @@
 	},
 	"version": "1.16.1",
 	"dependencies": {
-		"blade-formatter": "1.44.0",
-		"prettier": "3.6.2"
+		"blade-formatter": "1.44.0"
+	},
+	"peerDependencies": {
+		"prettier": "^3.0.0"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "1.9.4",
@@ -17,6 +19,7 @@
 		"cross-env": "^10.0.0",
 		"esbuild": "^0.25.0",
 		"esbuild-node-externals": "^1.4.1",
+		"prettier": "3.6.2",
 		"ts-node": "^10.5.0",
 		"typescript": "^5.0.0",
 		"vitest": "^3.0.0"


### PR DESCRIPTION
# Move Prettier to `peerDependencies`
Hi there 👋

This PR moves Prettier from dependencies to `peerDependencies` and `devDependencies`.

Why?
- Having Prettier as a dependency meant the plugin always installed its own version, which clashes with whatever version the user already has. For example, the digital agency I work with uses a fork of prettier to work with WordPress coding standards (`npm:wp-prettier@^3.0.3`)
- By making `prettier` a peer dependency, this ensures only one version of Prettier is used in a project.
- Prettier is also added to `devDependencies` for development and testing of the plugin.

Would you be able to consider this change? This change also makes sure the plugin follows best practices for Prettier plugins. 

Solves https://github.com/shufo/prettier-plugin-blade/issues/312