### PR TITLE
chore: add npm homepage and bugs metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,10 @@
 		"type": "git",
 		"url": "https://github.com/shufo/prettier-plugin-blade.git"
 	},
+	"homepage": "https://github.com/shufo/prettier-plugin-blade#readme",
+	"bugs": {
+		"url": "https://github.com/shufo/prettier-plugin-blade/issues"
+	},
 	"files": [
 		"dist",
 		"src",


### PR DESCRIPTION
## Summary

- add the standard npm `homepage` metadata pointing to the repository README
- add `bugs.url` so registry clients can link directly to the issue tracker
- keep the patch metadata-only with no formatter, dependency, or entrypoint changes

Closes #372

## Validation

- `yarn run build` (ESM and CommonJS builds passed)
- `biome lint .` (36 files checked)
- `pnpm pack --dry-run --json`
- direct Node assertions for both metadata values
- `git diff --check`

## Test environment note

I also ran the Vitest suite on Windows. The suite starts, but its CLI tests execute the POSIX `node_modules/.bin/prettier` shim with Node, and fixture assertions retain CRLF line endings; Tailwind lookup tests additionally scan a sandbox-restricted parent directory. These existing Windows-specific failures are unrelated to this `package.json`-only change. The repository's Linux CI should provide the authoritative full-suite result.